### PR TITLE
Fix call to mine function

### DIFF
--- a/views/distributed.jade
+++ b/views/distributed.jade
@@ -52,7 +52,7 @@ block content
           var l = Ladda.create(this);
           l.start();
           setTimeout(function() {
-              mine(block, chain);
+              mine(block, chain, true);
               l.stop();
             }, 250); // give UI time to update
         });


### PR DESCRIPTION
The `mine` function optionally accepts a third true / false parameter called "isChain". If true, rather than simply recalculating the current block, it updates any previous blocks as well. This wasn't being called properly in `views/distributed.jade`.

Hat tip to @grempe for this one.