### PR TITLE
disable 'previous' field

### DIFF
--- a/views/includes/block.jade
+++ b/views/includes/block.jade
@@ -21,12 +21,12 @@
     #state.form-group
       label.col-sm-2.control-label(for='block#{block.block}chain#{block.chain}previous') Prev:
       .col-sm-10
-        input.form-control(id='block#{block.block}chain#{block.chain}previous', type='text', value='#{block.previous}')
+        input.form-control(id='block#{block.block}chain#{block.chain}previous', type='text', value='#{block.previous}', disabled)
 
     #state.form-group
       label.col-sm-2.control-label(for='block#{block.block}chain#{block.chain}hash') Hash:
       .col-sm-10
-        input.form-control(id='block#{block.block}chain#{block.chain}hash', type='text' disabled)
+        input.form-control(id='block#{block.block}chain#{block.chain}hash', type='text', disabled)
 
     .form-group
       .col-sm-2


### PR DESCRIPTION
As the "previous" field holds a hash that is copied up from the previous block, make it disabled because altering it by hand isn't something that you should be able to do. (which is why it lacked a onKeyUp method as well)