### PR TITLE
Adding Spanish and allowing the Portuguese configuration to load

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,7 +56,7 @@ app.use(function(err, req, res, next) {
 });
 
 i18n.configure({
-  locales:['en', 'ja'],
+  locales:['en', 'ja', 'pt', 'es'],
   directory: __dirname + '/locales'
 });
 

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,19 @@
+{
+	"Hash": "Hash",
+	"Blockchain Demo": "Demo de Blockchain",
+	"Block": "Bloque",
+	"Blockchain": "Blockchain",
+	"Distributed": "Distribuído",
+	"Tokens": "Tokens",
+	"Coinbase": "Coinbase",
+	"Data": "Datos",
+	"Nonce": "Nonce",
+	"Mine": "Minar",
+	"Prev": "Anterior",
+	"Distributed Blockchain": "Blockchain distribuída",
+	"Peer": "Peer",
+	"Tx": "Tx",
+	"$": "$",
+	"From": "De",
+	"Coinbase Transactions": "Transacciones Coinbase"
+}


### PR DESCRIPTION
This adds a Spanish configuration and addresses this issue:
https://github.com/anders94/blockchain-demo/issues/29