### PR TITLE
Block difficulty configurable via queryString for blocks tab

### DIFF
--- a/public/javascripts/blockchain.js
+++ b/public/javascripts/blockchain.js
@@ -1,4 +1,4 @@
-var difficulty = 4;        // number of zeros required at front of hash
+var difficulty = window.location.search.split("?difficulty=")[1] || 4;// number of zeros required at front of hash
 var maximumNonce = 500000; // limit the nonce to this so we don't mine too long
 
 // NOTE: Because there are 16 possible characters in a hex value, each time you increment

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -40,7 +40,7 @@ html
             li(class={active: page === 'hash'})
               a(href='/hash') #{__('Hash')}
             li(class={active: page === 'block'})
-              a(href='/block') #{__('Block')}
+              a(href='/block?difficulty=4') #{__('Block')}
             li(class={active: page === 'blockchain'})
               a(href='/blockchain') #{__('Blockchain')}
             li(class={active: page === 'distributed'})


### PR DESCRIPTION
I am providing difficulty for "blocks" tab from query string.
This required minimum change in current code and it will help explain concept of difficulty while introducing nonce for a block.

If you want then I can take this concept forward for all tabs.